### PR TITLE
bump type versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "vscode-text-pastry",
   "displayName": "Text Pastry",
   "description": "Extend the power of multiple selections in VS Code. Modify selections, insert numeric sequences, incremental numbers, generate uuids, date ranges, insert continuously from a word list and more.",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "publisher": "jkjustjoshing",
   "engines": {
-    "vscode": "^1.51.0"
+    "vscode": "^1.72.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I started experiencing `command 'extension.textPastry.0toX' not found` after I updated to a more recent version of VS Code, at least 1.85.0.

Re-bundling and bumping the type versions seems to have fix it. This is my first extension contribution though so take my fix with a grain of salt 😅 . In any case, installing from a local vsix has fixed the issue for me.

**edit:** I did also `npm install` and `npm run vscode:prepublish` with a recent version of nodejs when I installed locally, `v20.11.0`.
